### PR TITLE
using standalone electron-builder config file

### DIFF
--- a/.electron-builder.js
+++ b/.electron-builder.js
@@ -1,0 +1,52 @@
+const { name, productName, appId, version } = require('./package.json');
+const icon = require('./lib/icon.js')('build');
+const iconGlob = require('./lib/icon.js')('glob');
+
+const fileName = productName.replace(/\s/g, '');
+
+module.exports = {
+  appId,
+  productName,
+  buildVersion: version,
+  files: [
+    '!assets/*',
+    '!scripts/*',
+    '!.*'
+  ],
+  mac: {
+    icon,
+    target: [
+      'dmg'
+    ],
+    darkModeSupport: true
+  },
+  dmg: {
+    icon,
+    artifactName: `${fileName}-v\${version}-MacOS-setup.\${ext}`
+  },
+  win: {
+    icon,
+    target: [
+      'nsis',
+      'portable'
+    ]
+  },
+  nsis: {
+    artifactName: `${fileName}-v\${version}-Windows-setup.\${ext}`
+  },
+  portable: {
+    artifactName: `${fileName}-v\${version}-Windows-portable.\${ext}`
+  },
+  linux: {
+    icon,
+    target: [
+      'AppImage'
+    ],
+    executableName: productName,
+    category: 'Network',
+    asarUnpack: [ iconGlob ]
+  },
+  appImage: {
+    artifactName: `${fileName}-v\${version}-Linux.\${ext}`
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: CI
 
 on:
@@ -22,7 +19,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: windows-artifacts
-          path: dist/fair*.exe
+          path: dist/*.exe
   macos:
     runs-on: macos-latest
     steps:
@@ -36,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: macos-artifacts
-          path: dist/fair*.dmg
+          path: dist/*.dmg
   linux:
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: linux-artifacts
-          path: dist/fair*.AppImage
+          path: dist/*.AppImage
   release:
     runs-on: ubuntu-latest
     needs: [ windows, macos, linux ]

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ coverage/
 .fair-compare-config.json
 out/
 dist/
+icons/

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -1,35 +1,31 @@
 const path = require('path');
 const is = require('./is.js');
 
-const osMap = {
-  win32: 'win',
-  darwin: 'mac',
-  linux: 'linux'
-};
-
 const iconMap = {
-  win: 'out/icon.ico',
-  linux: 'out/32x32.png',
-  mac: 'out/icon.icns'
+  'win32-runtime': 'icons/icon.ico',
+  'linux-runtime': 'icons/32x32.png',
+  'linux-build': 'icons/256x256.png',
+  'linux-glob': 'icons/*.png',
+  'darwin-runtime': 'icons/icon.icns'
 };
 
-module.exports = () => {
-  const os = osMap[process.platform];
-  let icon = os ? path.resolve(__dirname, '..', iconMap[os]) : undefined;
+module.exports = (type = 'runtime') => {
+  const iconName = iconMap[`${process.platform}-${type}`] || iconMap[`${process.platform}-runtime`];
+  let icon = iconName ? path.resolve(__dirname, '..', iconName) : undefined;
 
-  if (icon) {
-    icon = path.resolve(__dirname, '..', icon);
+  if (type === 'build') {
+    return icon;
   }
 
   if (icon && is.prod) {
     icon = icon.replace('app.asar', 'app.asar.unpacked');
   }
 
-  if (os === 'win' && !is.prod) {
+  if (process.platform === 'win32' && !is.prod) {
     return icon;
   }
 
-  if (os === 'linux') {
+  if (process.platform === 'linux') {
     return icon;
   }
 };

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -13,7 +13,7 @@ module.exports = (type = 'runtime') => {
   const iconName = iconMap[`${process.platform}-${type}`] || iconMap[`${process.platform}-runtime`];
   let icon = iconName ? path.resolve(__dirname, '..', iconName) : undefined;
 
-  if (type === 'build') {
+  if (['build', 'glob'].includes(type)) {
     return icon;
   }
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "npm run -s prep:icons",
     "prep": "npm run -s prep:icons",
-    "prep:icons": "svg-app-icon --destination out < assets/icon.svg",
+    "prep:icons": "svg-app-icon --destination icons < assets/icon.svg",
     "prepackage": "npm run -s prep",
     "package": "run-script-os",
-    "package:win32": "electron-builder --publish never --win",
-    "package:darwin": "electron-builder --publish never --mac",
-    "package:linux": "electron-builder --publish never --linux",
+    "package:win32": "electron-builder --config .electron-builder.js --publish never --win",
+    "package:darwin": "electron-builder --config .electron-builder.js --publish never --mac",
+    "package:linux": "electron-builder --config .electron-builder.js --publish never --linux",
     "package:default": "echo \"Error: this OS is not supported\" && exit 1"
   },
   "repository": {
@@ -57,50 +57,5 @@
     "pixelmatch": "^5.2.0",
     "preact": "^10.4.4",
     "toastify-js": "^1.8.0"
-  },
-  "build": {
-    "appId": "com.catdad.fair-compare",
-    "files": [
-      "!assets/*",
-      "!.*"
-    ],
-    "mac": {
-      "target": [
-        "dmg"
-      ],
-      "icon": "out/icon.icns",
-      "darkModeSupport": true
-    },
-    "dmg": {
-      "icon": "out/icon.icns",
-      "artifactName": "${name}-v${version}-macos-setup.${ext}"
-    },
-    "win": {
-      "target": [
-        "nsis",
-        "portable"
-      ],
-      "icon": "out/icon.ico"
-    },
-    "nsis": {
-      "artifactName": "${name}-v${version}-windows-setup.${ext}"
-    },
-    "portable": {
-      "artifactName": "${name}-v${version}-windows-portable.${ext}"
-    },
-    "linux": {
-      "icon": "out/256x256.png",
-      "target": [
-        "AppImage"
-      ],
-      "executableName": "Fair Compare",
-      "category": "Graphics",
-      "asarUnpack": [
-        "out/*.png"
-      ]
-    },
-    "appImage": {
-      "artifactName": "${name}-v${version}-linux.${ext}"
-    }
   }
 }


### PR DESCRIPTION
This allows us to use some logic when defining values rather than having to hard-code literals in json. This is in line with `electron-template`.